### PR TITLE
Add LoggingLevelFilter to Ensure Proper Log Level Filtering

### DIFF
--- a/django_logging/filters/level_filter.py
+++ b/django_logging/filters/level_filter.py
@@ -1,0 +1,38 @@
+import logging
+
+
+class LoggingLevelFilter(logging.Filter):
+    """
+    Filters log records based on their logging level.
+
+    This filter is used to prevent log records from being written to log files
+    intended for lower log levels. For example, if we have separate log
+    files for DEBUG, INFO, WARNING, and ERROR levels, this filter ensures that
+    a log record with level ERROR is only written to the ERROR log file, and not
+    to the DEBUG, INFO or WARNING log files.
+    """
+
+    def __init__(self, logging_level: int):
+        """
+        Initializes a LoggingLevelFilter instance.
+
+        Args:
+            logging_level: The logging level to filter on (e.g. logging.DEBUG, logging.INFO, etc.).
+
+        Returns:
+            None
+        """
+        super().__init__()
+        self.logging_level = logging_level
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """
+        Filters a log record based on its level.
+
+        Args:
+            record: The log record to filter.
+
+        Returns:
+            True if the log record's level matches the specified logging level, False otherwise.
+        """
+        return record.levelno == self.logging_level

--- a/django_logging/settings/conf.py
+++ b/django_logging/settings/conf.py
@@ -3,6 +3,8 @@ import logging.config
 import os
 from typing import List, Dict, Optional
 
+from django_logging.filters.level_filter import LoggingLevelFilter
+
 
 class LogConfig:
     """
@@ -67,6 +69,7 @@ class LogManager:
                 "filename": log_file,
                 "formatter": "default",
                 "level": level,
+                "filters": [level.lower()]
             }
             for level, log_file in self.log_files.items()
         }
@@ -74,6 +77,14 @@ class LogManager:
             "class": "logging.StreamHandler",
             "formatter": "console",
             "level": "DEBUG",
+        }
+
+        filters = {
+            level.lower(): {
+                "()": LoggingLevelFilter,
+                "logging_level": getattr(logging, level),
+            }
+            for level in self.log_config.log_levels
         }
 
         loggers = {
@@ -88,6 +99,7 @@ class LogManager:
         config = {
             "version": 1,
             "handlers": handlers,
+            "filters": filters,
             "loggers": loggers,
             "root": {"level": "DEBUG", "handlers": list(handlers.keys())},
             "disable_existing_loggers": False,


### PR DESCRIPTION
This pull request introduces the LoggingLevelFilter class and updates the logging configuration to ensure that log records are correctly filtered by their logging level. This enhancement prevents logs intended for higher levels (e.g., ERROR, CRITICAL) from being written to lower-level log files (e.g., DEBUG, INFO).

Key Changes:
Added:
LoggingLevelFilter class: Filters log records based on their logging level, ensuring they are written only to their respective log files. This class includes comprehensive docstrings for each method, explaining the initialization, usage, and filtering logic.
Updated:
Logging configuration in conf:
Applied the LoggingLevelFilter to each file handler to ensure proper log level filtering.
Updated the handlers dictionary to include the newly created filter for each log level.
Introduced a filters dictionary to manage the filters for each log level.
Ensured that each log level's handler is correctly associated with its corresponding filter.